### PR TITLE
DQN, cartpole and history len fix

### DIFF
--- a/dqn.py
+++ b/dqn.py
@@ -30,12 +30,7 @@ def learn(env,
     assert type(env.observation_space) == gym.spaces.Box
     assert type(env.action_space)      == gym.spaces.Discrete
 
-    if len(env.observation_space.shape) == 1:
-        # This means we are running on low-dimensional observations (e.g. RAM)
-        input_shape = env.observation_space.shape
-    else:
-        img_h, img_w, img_c = env.observation_space.shape
-        input_shape = (history_len, img_h, img_w, img_c)
+    input_shape = env.observation_space.shape if history_len == 1 else (history_len, *env.observation_space.shape)
 
     n_actions = env.action_space.n
 

--- a/dqn.py
+++ b/dqn.py
@@ -30,8 +30,7 @@ def learn(env,
     assert type(env.observation_space) == gym.spaces.Box
     assert type(env.action_space)      == gym.spaces.Discrete
 
-    input_shape = env.observation_space.shape if history_len == 1 else (history_len, *env.observation_space.shape)
-
+    input_shape = (history_len, *env.observation_space.shape)
     n_actions = env.action_space.n
 
     # build model

--- a/q_functions.py
+++ b/q_functions.py
@@ -15,7 +15,7 @@ class CartPoleNet(QFunction):
         return False
 
     def __call__(self, state, n_actions, scope):
-        hidden = state
+        hidden = flatten(state) # flatten to make sure 2-D
 
         with tf.variable_scope(scope):
             hidden  = dense(hidden, units=512,       activation=tf.nn.tanh)

--- a/utils.py
+++ b/utils.py
@@ -314,29 +314,16 @@ class ReplayBuffer(object):
         return self._encode_observation((self.next_idx - 1) % self.size)
 
     def _encode_observation(self, idx):
-        # this checks if we are using low-dimensional observations, such as RAM
-        # state, in which case we just directly return the latest RAM.
-        if len(self.obs.shape) == 2 and self.history_len == 1:
-            return self.obs[idx]
+        end   = idx + 1 # make noninclusive
+        start = end - self.history_len
 
-        end_idx   = idx + 1 # make noninclusive
-        start_idx = end_idx - self.history_len
-        # if there weren't enough frames ever in the buffer for context
-        if start_idx < 0 and self.num_in_buffer != self.size:
-            start_idx = 0
-        for idx in range(start_idx, end_idx - 1):
-            if self.done[idx % self.size]:
-                start_idx = idx + 1
-        missing_context = self.history_len - (end_idx - start_idx)
-        # if zero padding is needed for missing context
-        # or we are on the boundry of the buffer
-        if start_idx < 0 or missing_context > 0:
-            frames = [np.zeros_like(self.obs[0]) for _ in range(missing_context)]
-            for idx in range(start_idx, end_idx):
-                frames.append(self.obs[idx % self.size])
-            return np.array(frames)
-        else:
-            return self.obs[start_idx:end_idx]
+        pad_len = max(0, -start)
+        padding = [np.zeros_like(self.obs[0]) for _ in range(pad_len)]
+
+        start = max(0, start)
+        obs = [x for x in self.obs[start:end]]
+
+        return np.array(padding + obs)
 
     def store_frame(self, frame):
         """Store a single frame in the buffer at the next available index, overwriting

--- a/utils.py
+++ b/utils.py
@@ -314,12 +314,13 @@ class ReplayBuffer(object):
         return self._encode_observation((self.next_idx - 1) % self.size)
 
     def _encode_observation(self, idx):
-        end_idx   = idx + 1 # make noninclusive
-        start_idx = end_idx - self.history_len
         # this checks if we are using low-dimensional observations, such as RAM
         # state, in which case we just directly return the latest RAM.
-        if len(self.obs.shape) == 2:
-            return self.obs[end_idx-1]
+        if len(self.obs.shape) == 2 and self.history_len == 1:
+            return self.obs[idx]
+
+        end_idx   = idx + 1 # make noninclusive
+        start_idx = end_idx - self.history_len
         # if there weren't enough frames ever in the buffer for context
         if start_idx < 0 and self.num_in_buffer != self.size:
             start_idx = 0


### PR DESCRIPTION
Made some changes in the DQN input creation, replay buffer observation encoding and Cartpole network to allow all of these instances to have variable history lens